### PR TITLE
Changing WifiMonitor exposing method to Flow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Expose flow of `WifiStatus`
 
 # Version 1.1.1
 > 2021-06-10

--- a/README.md
+++ b/README.md
@@ -22,17 +22,10 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Or more simply
-        val monitor = WifiMonitor(context)
+        val monitorFlow = WifiMonitor(context).start()
         
-        // currently available information
-        monitor.info
- 
-        // observe changes
-        lifecycleScope.launchWhenStarted {
-            monitor.observe { freshInfo ->
-                
-            }
-        }
+        // last known information
+        monitorFlow.first()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
         mavenCentral()
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.1"
+        classpath "com.android.tools.build:gradle:4.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:5.12.5"
     }

--- a/src/main/java/net/kuama/wifiMonitor/WifiLiveData.kt
+++ b/src/main/java/net/kuama/wifiMonitor/WifiLiveData.kt
@@ -9,10 +9,11 @@ class WifiLiveData constructor(private val monitor: WifiMonitor) :
 
     private var startJob: Job? = null
 
+    @ExperimentalCoroutinesApi
     override fun onActive() {
         super.onActive()
         startJob = CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
-            monitor.observe(::postValue)
+            monitor.start()
         }
     }
 

--- a/src/main/java/net/kuama/wifiMonitor/WifiLiveData.kt
+++ b/src/main/java/net/kuama/wifiMonitor/WifiLiveData.kt
@@ -2,6 +2,7 @@ package net.kuama.wifiMonitor
 
 import androidx.lifecycle.LiveData
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.collect
 import net.kuama.wifiMonitor.data.WifiStatus
 
 class WifiLiveData constructor(private val monitor: WifiMonitor) :
@@ -9,11 +10,14 @@ class WifiLiveData constructor(private val monitor: WifiMonitor) :
 
     private var startJob: Job? = null
 
+    @OptIn(InternalCoroutinesApi::class)
     @ExperimentalCoroutinesApi
     override fun onActive() {
         super.onActive()
         startJob = CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
-            monitor.start()
+            monitor.start().collect { wifiStatus ->
+                postValue(wifiStatus)
+            }
         }
     }
 

--- a/src/main/java/net/kuama/wifiMonitor/WifiMonitor.kt
+++ b/src/main/java/net/kuama/wifiMonitor/WifiMonitor.kt
@@ -46,8 +46,6 @@ class WifiMonitor(context: Context) {
                 WifiStatus.NetworkBand.WIFI_2_4_GHZ
             }
 
-    private var wifiStatus: WifiStatus = WifiStatus(State.UNKNOWN)
-
     /**
      * True if the user granted access to [Manifest.permission.ACCESS_FINE_LOCATION]
      */
@@ -62,6 +60,7 @@ class WifiMonitor(context: Context) {
      */
     @ExperimentalCoroutinesApi
     suspend fun start(): Flow<WifiStatus> = callbackFlow {
+        var wifiStatus: WifiStatus
         listener.start {
             // Update wifiStatus value accordingly with the new state
             wifiStatus = when (state) {
@@ -83,7 +82,7 @@ class WifiMonitor(context: Context) {
                 // Publish value to the Flow
                 channel.offer(wifiStatus)
             } catch (e: Exception) {
-                Log.d(TAG, "Send channel is closed, it wasn't possible to publish a new value", e)
+                Log.w(TAG, "Send channel is closed, it wasn't possible to publish a new value", e)
             }
         }
         awaitClose {

--- a/src/main/java/net/kuama/wifiMonitor/WifiMonitor.kt
+++ b/src/main/java/net/kuama/wifiMonitor/WifiMonitor.kt
@@ -5,15 +5,22 @@ import android.content.Context
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import net.kuama.wifiMonitor.data.WifiStatus
+import net.kuama.wifiMonitor.data.WifiStatus.State
 import net.kuama.wifiMonitor.implementation.AndroidQWifiListener
 import net.kuama.wifiMonitor.implementation.BeforeAndroidQWifiListener
 
 class WifiMonitor(context: Context) {
+    companion object {
+        private val TAG = WifiMonitor::class.simpleName
+    }
 
     private val listener = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         AndroidQWifiListener(context)
@@ -25,27 +32,6 @@ class WifiMonitor(context: Context) {
     private val wifiManager: WifiManager =
         context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
 
-    /**
-     * Whether we received at least a Wi-Fi change status. When false, we cannot say we are connected
-     */
-    private var didReceiveChange = false
-
-    /**
-     * Stop listening to Wi-Fi changes
-     */
-    fun stop() = listener.stop()
-
-    /**
-     * Triggers the on change callback whenever the Wi-Fi changes its status
-     */
-    suspend fun observe(onChange: (WifiStatus) -> Unit) =
-        withContext(Dispatchers.Default) {
-            listener.start {
-                didReceiveChange = true
-                onChange(info)
-            }
-        }
-
     private val state: Int
         get() = wifiManager.wifiState
 
@@ -53,38 +39,14 @@ class WifiMonitor(context: Context) {
         get() = wifiManager.connectionInfo
 
     private val band: WifiStatus.NetworkBand
-        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        get() =
             if (connectionInfo.frequency > 3000) {
                 WifiStatus.NetworkBand.WIFI_5_GHZ
             } else {
                 WifiStatus.NetworkBand.WIFI_2_4_GHZ
             }
-        } else {
-            WifiStatus.NetworkBand.UNKNOWN
-        }
 
-    /**
-     * Holds the current information on the Wi-Fi connection.
-     */
-    val info: WifiStatus
-        get() = if (didReceiveChange) {
-            when (state) {
-                WifiManager.WIFI_STATE_DISABLED, WifiManager.WIFI_STATE_DISABLING -> WifiStatus(
-                    WifiStatus.State.DISCONNECTED
-                )
-                WifiManager.WIFI_STATE_ENABLED -> WifiStatus(
-                    state = if (isFineLocationAccessGranted) WifiStatus.State.CONNECTED else WifiStatus.State.CONNECTED_MISSING_FINE_LOCATION_PERMISSION,
-                    ssid = connectionInfo.ssid,
-                    bssid = connectionInfo.bssid,
-                    band = band,
-                    rssi = connectionInfo.rssi
-                )
-                WifiManager.WIFI_STATE_ENABLING -> WifiStatus(WifiStatus.State.ENABLING)
-                else -> WifiStatus(WifiStatus.State.UNKNOWN)
-            }
-        } else {
-            WifiStatus(WifiStatus.State.UNKNOWN)
-        }
+    private var wifiStatus: WifiStatus = WifiStatus(State.UNKNOWN)
 
     /**
      * True if the user granted access to [Manifest.permission.ACCESS_FINE_LOCATION]
@@ -93,4 +55,45 @@ class WifiMonitor(context: Context) {
         context,
         Manifest.permission.ACCESS_FINE_LOCATION
     ) == PERMISSION_GRANTED
+
+    /**
+     * Start listening to Wi-fi changes exposing a flow of WifiStatus.
+     * It can throw an exception when the channel publishing on a channel that is closed
+     */
+    @ExperimentalCoroutinesApi
+    suspend fun start(): Flow<WifiStatus> = callbackFlow {
+        listener.start {
+            // Update wifiStatus value accordingly with the new state
+            wifiStatus = when (state) {
+                WifiManager.WIFI_STATE_DISABLED, WifiManager.WIFI_STATE_DISABLING -> WifiStatus(
+                    State.DISCONNECTED
+                )
+                WifiManager.WIFI_STATE_ENABLED -> WifiStatus(
+                    state = if (isFineLocationAccessGranted) State.CONNECTED else State.CONNECTED_MISSING_FINE_LOCATION_PERMISSION,
+                    ssid = connectionInfo.ssid,
+                    bssid = connectionInfo.bssid,
+                    band = band,
+                    rssi = connectionInfo.rssi
+                )
+                WifiManager.WIFI_STATE_ENABLING -> WifiStatus(State.ENABLING)
+                else -> WifiStatus(State.UNKNOWN)
+            }
+            // Surrounding with try-catch because the channel may be closed
+            try {
+                // Publish value to the Flow
+                channel.offer(wifiStatus)
+            } catch (e: Exception) {
+                Log.d(TAG, "Send channel is closed, it wasn't possible to publish a new value", e)
+            }
+        }
+        awaitClose {
+            wifiStatus = WifiStatus(State.UNKNOWN)
+            stop()
+        }
+    }
+
+    /**
+     * Stop listening to Wi-Fi changes
+     */
+    fun stop() = listener.stop()
 }


### PR DESCRIPTION
WifiMonitor exposes a flow of WifiStatus via start() method.
After creating a WifiMonitor object, start() should be called to start publishing in the flow.
Moved the original logic accordingly with the Flow specifications.
Close #6 